### PR TITLE
get rid of .babelrc from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 __tests__
+.babelrc


### PR DESCRIPTION
for details see https://github.com/babel/babel/issues/4707