### PR TITLE
Call throttleEnd with last arguments within `wait` period

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 build
 coverage
 .DS_Store
+.idea

--- a/src/function/__tests__/throttleEnd.js
+++ b/src/function/__tests__/throttleEnd.js
@@ -11,12 +11,15 @@ describe('utils/function/throttleEnd', () => {
         throttled.call({ a: 1 }, 1, 2);
         throttled.call({ a: 2 }, 3, 4);
         throttled.call({ a: 3 }, 5, 6);
+
         expect(f.mock.calls).toHaveLength(0);
         jest.runAllTimers();
         expect(f.mock.calls).toHaveLength(1);
-        expect(f).toBeCalledWith(1, 2);
-        expect(context).toEqual({ a: 1 });
+        expect(f).toBeCalledWith(5, 6);
+        expect(context).toEqual({ a: 3 });
+
         throttled.call({ a: 4 }, 7);
+
         expect(f.mock.calls).toHaveLength(1);
         jest.runAllTimers();
         expect(f.mock.calls).toHaveLength(2);

--- a/src/function/throttleEnd.js
+++ b/src/function/throttleEnd.js
@@ -9,6 +9,8 @@ import curryN from './curryN';
  */
 export default curryN(2, (wait, fn) => {
     let lastCalled;
+    let lastArgs;
+    let lastThis;
     let timeout;
 
     return function(...args) {
@@ -21,11 +23,13 @@ export default curryN(2, (wait, fn) => {
             fn.apply(this, args);
         } else if (!timeout) {
             timeout = setTimeout(() => {
-                fn.apply(this, args);
+                fn.apply(lastThis, lastArgs);
                 timeout = null;
             }, wait);
         }
 
         lastCalled = now;
+        lastArgs = args;
+        lastThis = this;
     };
 });


### PR DESCRIPTION
Now, when a function throttled with throttleEnd is invoked several times within a wait period it is finally called by throttleEnd with arguments, provided at last! invoke.

Resolves: #9