### PR TITLE
Extend find* utilities passed arguments to callback.

### DIFF
--- a/src/array/__tests__/find.js
+++ b/src/array/__tests__/find.js
@@ -6,4 +6,15 @@ describe('utils/array/find', () => {
         expect(find(a => a % 2 === 0)([1, 2, 3, 4])).toBe(2);
         expect(find(a => a > 100, [1, 2, 3])).toBeUndefined();
     });
+
+    it('test callback parameters', () => {
+        const fn = jest.fn();
+        const arr = [1, 2, 3];
+
+        find(fn, arr);
+
+        expect(fn).toHaveBeenCalledWith(1, 0, arr);
+        expect(fn).toHaveBeenCalledWith(2, 1, arr);
+        expect(fn).toHaveBeenCalledWith(3, 2, arr);
+    });
 });

--- a/src/array/__tests__/findIndex.js
+++ b/src/array/__tests__/findIndex.js
@@ -6,4 +6,15 @@ describe('utils/array/findIndex', () => {
         expect(findIndex(a => a % 2 === 0)([1, 2, 3, 4])).toBe(1);
         expect(findIndex(a => a > 100, [1, 2, 3])).toBe(-1);
     });
+
+    it('test callback parameters', () => {
+        const fn = jest.fn();
+        const arr = [1, 2, 3];
+
+        findIndex(fn, arr);
+
+        expect(fn).toHaveBeenCalledWith(1, 0, arr);
+        expect(fn).toHaveBeenCalledWith(2, 1, arr);
+        expect(fn).toHaveBeenCalledWith(3, 2, arr);
+    });
 });

--- a/src/array/__tests__/findLast.js
+++ b/src/array/__tests__/findLast.js
@@ -6,4 +6,15 @@ describe('utils/array/findLast', () => {
         expect(findLast(a => a === 4, [1, 2, 3])).toBeUndefined();
         expect(findLast(a => a === 4, [])).toBeUndefined();
     });
+
+    it('test callback parameters', () => {
+        const fn = jest.fn();
+        const arr = [1, 2, 3];
+
+        findLast(fn, arr);
+
+        expect(fn).toHaveBeenCalledWith(3, 2, arr);
+        expect(fn).toHaveBeenCalledWith(2, 1, arr);
+        expect(fn).toHaveBeenCalledWith(1, 0, arr);
+    });
 });

--- a/src/array/find.js
+++ b/src/array/find.js
@@ -16,7 +16,7 @@ import curryN from '../function/curryN';
  */
 export default curryN(2, (fn, arr = []) => {
     for (let i = 0; i < arr.length; i++) {
-        if (fn(arr[i])) {
+        if (fn(arr[i], i, arr)) {
             return arr[i];
         }
     }

--- a/src/array/findIndex.js
+++ b/src/array/findIndex.js
@@ -16,7 +16,7 @@ import curryN from '../function/curryN';
  */
 export default curryN(2, (fn, arr = []) => {
     for (let i = 0; i < arr.length; i++) {
-        if (fn(arr[i])) {
+        if (fn(arr[i], i, arr)) {
             return i;
         }
     }

--- a/src/array/findLast.js
+++ b/src/array/findLast.js
@@ -19,7 +19,7 @@ export default curry((fn, list) => {
     let idx = list.length - 1;
 
     while (idx >= 0) {
-        if (fn(list[idx])) {
+        if (fn(list[idx], idx, list)) {
             return list[idx];
         }
 

--- a/src/object/__tests__/findKey.js
+++ b/src/object/__tests__/findKey.js
@@ -8,4 +8,15 @@ describe('utils/object/findKey', () => {
         expect(findKey(x => x > 3, { a: 4, b: 5 })).toBe('a');
         expect(findKey(x => x > 3, { a: 3, b: 5 })).toBe('b');
     });
+
+    it('test callback parameters', () => {
+        const fn = jest.fn();
+        const obj = { a: 1, b: 2, c: 3 };
+
+        findKey(fn, obj);
+
+        expect(fn).toHaveBeenCalledWith(1, 'a', obj);
+        expect(fn).toHaveBeenCalledWith(2, 'b', obj);
+        expect(fn).toHaveBeenCalledWith(3, 'c', obj);
+    });
 });


### PR DESCRIPTION
According to spec Array.prototype.find and Array.prototype.findIndex passes three arguments to callback function: element, index and array. Extend current implementation according to spec.

Resolves: #15