### PR TITLE
feat(object): extend object methods to extend properties

### DIFF
--- a/src/__tests__/assign.ts
+++ b/src/__tests__/assign.ts
@@ -1,0 +1,23 @@
+import assign from '../assign';
+
+describe('utils/assign', () => {
+    it('should create new object', () => {
+        const a = { a: 1 };
+        const b = { b: 2 };
+        const res = assign(a, b);
+
+        expect(res).not.toBe(a);
+        expect(res).toEqual({ a: 1, b: 2 });
+        expect(a).toEqual({ a: 1 });
+    });
+
+    it('should create new array', () => {
+        const a = [1, 2, 3];
+        const b = [4, 5];
+        const res = assign(a, b);
+
+        expect(res).not.toBe(a);
+        expect(res).toEqual([4, 5, 3]);
+        expect(a).toEqual([1, 2, 3]);
+    });
+});

--- a/src/array/splitEvery.ts
+++ b/src/array/splitEvery.ts
@@ -10,7 +10,7 @@ interface SplitEvery {
     };
 }
 
-/*
+/**
  * Splits a collection into slices of the specified length
  *
  * @param {Number} length desired length of slices

--- a/src/assign.ts
+++ b/src/assign.ts
@@ -1,0 +1,30 @@
+import isArray from './is/array';
+
+export interface Assign {
+    <T>(a: T): T;
+    <T1, T2>(a: T1, b: T2): T1 & T2;
+    <T1, T2, T3>(a: T1, b: T2, c: T3): T1 & T2 & T3;
+    <T>(...args: T[]): T;
+}
+
+/**
+ * Create a new object/array with the own properties of the first entry merged with
+ * the own properties of the others objects. If a key exists in several objects,
+ * the value from the last object will be used.
+ *
+ * **Note** if first argument is array then result of function is array,
+ * otherwise it is an object.
+ *
+ * @param sources
+ * @example
+ *
+ * assign({a:1}, {b:2}) // => {a:1, b:2}
+ * assign([1,2,3], [4,5]) // => [4,5,3]
+ */
+export default ((...sources) => {
+    if (isArray(sources[0])) {
+        return Object.assign([], ...sources);
+    }
+
+    return Object.assign({}, ...sources);
+}) as Assign;

--- a/src/object/__tests__/pathApply.ts
+++ b/src/object/__tests__/pathApply.ts
@@ -7,14 +7,12 @@ describe('utils/object/pathApply', () => {
         const obj = { a: { b: { c: 'test' } } };
 
         expect(pathApply(['a', 'b', 'c'], f, obj)).toBe('test');
-        expect(f).toBeCalledWith('test');
+        expect(f).toBeCalledWith('test', ['a', 'b', 'c'], obj);
 
         expect(pathApply(['a', 'b', 'd'], f, obj)).toBeUndefined();
-        expect(f).toBeCalledWith(undefined);
+        expect(f).toBeCalledWith(undefined, ['a', 'b', 'd'], obj);
 
         expect(pathApply(['a', 'b'], f)(obj)).toEqual({ c: 'test' });
-        expect(f).toBeCalledWith({ c: 'test' });
+        expect(f).toBeCalledWith({ c: 'test' }, ['a', 'b'], obj);
     });
 });
-
-const a = pathApply(['a', 'b'], (x: string) => x, { a: 1, b: 'fwf' });

--- a/src/object/__tests__/pathSet.ts
+++ b/src/object/__tests__/pathSet.ts
@@ -18,4 +18,24 @@ describe('utils/object/pathSet', () => {
         expect(obj.a.b.c).toBe(3);
         expect(res).toEqual({ a: { b: { c: 'hello' } } });
     });
+
+    it('should set values into array', () => {
+        const obj = { a: [1, 2, { b: 2 }] };
+
+        expect(pathSet(['a', 1], 5, obj)).toEqual({ a: [1, 5, { b: 2 }] });
+        expect(pathSet(['a', 2, 'b'], 'test', obj)).toEqual({ a: [1, 2, { b: 'test' }] });
+        expect(pathSet(['b', 0], 'arr', obj)).toEqual({ a: [1, 2, { b: 2 }], b: ['arr'] });
+    });
+
+    it('should return object itself if value is the same', () => {
+        const obj = { a: { b: { c: 3 } } };
+        const a = pathSet(['a', 'b', 'c'], 3, obj);
+        const b = pathSet(['a', 'b', 'c'], 5, obj);
+        const c = pathSet(['a', 'b'], { c: 3 }, obj);
+
+        expect(a).toBe(obj);
+        expect(b).not.toBe(obj);
+        expect(c).not.toBe(obj);
+        expect(c).toEqual(obj);
+    });
 });

--- a/src/object/__tests__/pathSetBy.ts
+++ b/src/object/__tests__/pathSetBy.ts
@@ -1,0 +1,29 @@
+import pathSetBy from '../pathSetBy';
+
+describe('utils/object/pathSetBy', () => {
+    it('should call function with current value and set the result of call', () => {
+        const fn = jest.fn((val) => val + 1);
+        const obj = { a: { b: { c: 1 } } };
+        const res = pathSetBy(['a', 'b', 'c'], fn, obj);
+
+        expect(res).not.toBe(obj);
+        expect(res).toEqual({ a: { b: { c: 2 } } });
+        expect(fn).toHaveBeenCalledWith(1, ['a', 'b', 'c'], obj);
+    });
+
+    it('should not return new reference if value didnt change', () => {
+        const obj = { a: { b: { c: 1 } } };
+        const res = pathSetBy(['a', 'b', 'c'], (v) => v, obj);
+
+        expect(res).toBe(obj);
+        expect(res).toEqual({ a: { b: { c: 1 } } });
+    });
+
+    it('should set values into array', () => {
+        const obj = { a: [1, 2, { b: 2 }] };
+
+        expect(pathSetBy(['a', 1], (x) => x + 1, obj)).toEqual({ a: [1, 3, { b: 2 }] });
+        expect(pathSetBy(['a', 2, 'b'], (x) => 'other', obj)).toEqual({ a: [1, 2, { b: 'other' }] });
+        expect(pathSetBy(['b', 0], (x) => 'arr', obj)).toEqual({ a: [1, 2, { b: 2 }], b: ['arr'] });
+    });
+});

--- a/src/object/__tests__/propApply.ts
+++ b/src/object/__tests__/propApply.ts
@@ -6,9 +6,9 @@ describe('utils/object/propApply', () => {
         const f = jest.fn(identity);
 
         expect(propApply('a', f, { a: 5 })).toBe(5);
-        expect(f).toBeCalledWith(5);
+        expect(f).toBeCalledWith(5, 'a', { a: 5 });
 
         expect(propApply('a', f, {})).toBeUndefined();
-        expect(f).toBeCalledWith(undefined);
+        expect(f).toBeCalledWith(undefined, 'a', {});
     });
 });

--- a/src/object/__tests__/propSet.ts
+++ b/src/object/__tests__/propSet.ts
@@ -6,4 +6,16 @@ describe('utils/object/propSet', () => {
         expect(propSet('a', 5, { a: 1 })).toEqual({ a: 5 });
         expect(propSet('a', 4, null)).toEqual({ a: 4 });
     });
+
+    it('should not create new object if value is the same', () => {
+        const obj = { a: 1, b: 2 };
+        const a = propSet('a', 1, obj);
+        const b = propSet('a', 2)(obj);
+        const c = propSet('a')('test')(obj);
+
+        expect(a).toBe(obj);
+        expect(b).not.toBe(obj);
+        expect(c).not.toBe(obj);
+        expect(c).toEqual({ a: 'test', b: 2 });
+    });
 });

--- a/src/object/__tests__/propSetBy.ts
+++ b/src/object/__tests__/propSetBy.ts
@@ -1,0 +1,21 @@
+import propSetBy from '../propSetBy';
+
+describe('utils/object/propSetBy', () => {
+    it('should call function with current prop and set the result of call', () => {
+        const fn = jest.fn((val) => val + 1);
+        const obj = { a: 1 };
+        const res = propSetBy('a', fn, obj);
+
+        expect(res).not.toBe(obj);
+        expect(res).toEqual({ a: 2 });
+        expect(fn).toHaveBeenCalledWith(1, 'a', obj);
+    });
+
+    it('should not return new reference if value didnt change', () => {
+        const obj = { a: 1 };
+        const res = propSetBy('a', (v) => v, obj);
+
+        expect(res).toBe(obj);
+        expect(res).toEqual({ a: 1 });
+    });
+});

--- a/src/object/mergeDeep.ts
+++ b/src/object/mergeDeep.ts
@@ -1,8 +1,8 @@
 import curryN from '../function/curryN';
 import isPlainObject from '../is/plainObject';
-import isArray from '../is/array';
 import objectKeys from './keys';
 import { Merge } from './merge';
+import assign from '../assign';
 
 /**
  * Create a new object with the own properties of the first object deeply merged with
@@ -16,7 +16,7 @@ import { Merge } from './merge';
  * mergeDeep({ 'name': 'fred', 'info': { 'age': 10, 'sex': 'm' } }, { 'info': { 'age': 40 }); //=> { 'name': 'fred', 'info': { 'age': 40, 'sex': 'm' } }
  */
 const mergeDeep = (...sources: Record<any, any>[]) => {
-    const result = Object.assign(isArray(sources[0]) ? [] : {}, sources[0] || {});
+    const result = assign(sources[0] || {});
 
     for (let i = 1; i < sources.length; i++) {
         const src = sources[i];

--- a/src/object/mergeWith.ts
+++ b/src/object/mergeWith.ts
@@ -1,5 +1,6 @@
 import curryN from '../function/curryN';
 import objectKeys from './keys';
+import assign from '../assign';
 
 type Func<T1, T2, R> = (
     v1: T1[keyof T1] | T2[keyof T2],
@@ -34,7 +35,7 @@ interface MergeWith {
  * mergeWith((x, y) => x + y, { 'name': 'fred', 'age': 10 }, { 'age': 40 }); //=> { 'name': 'fred', 'age': 50 }
  */
 export default curryN(3, (fn: Func<any, any, any>, ...sources) => {
-    const result: Record<any, any> = Object.assign({}, sources[0]);
+    const result: Record<any, any> = assign(sources[0]);
 
     for (let i = 1; i < sources.length; i++) {
         const source = sources[i];

--- a/src/object/pathApply.ts
+++ b/src/object/pathApply.ts
@@ -1,19 +1,19 @@
-import { Paths, Prop } from '../typings/types';
+import { Paths, Prop, ObjBase } from '../typings/types';
 import curryN from '../function/curryN';
 import path from './path';
 
 interface PathApply {
-    <K extends Prop, O extends Record<K, any>, R>(path: [K], fn: (x: O[K]) => R, obj: O): R;
-    <K extends Prop, R>(path: [K], fn: (x) => R): (obj) => R;
+    <K extends Prop, O extends Record<K, any>, R>(path: [K], fn: ObjBase<K, O[K], R>, obj: O): R;
+    <K extends Prop, V, R>(path: [K], fn: ObjBase<K, V, R>): (obj) => R;
     <K extends Prop>(path: [K]): {
-        <R>(fn: (x) => R, obj): R;
-        <R>(fn: (x) => R): (obj) => R;
+        <O extends Record<K, any>, R>(fn: ObjBase<K, O[K], R>, obj: O): R;
+        <V, R>(fn: ObjBase<K, V, R>): (obj) => R;
     };
-    <R>(path: Paths, fn: (x) => R, obj): R | undefined;
-    <R>(path: Paths, fn: (x) => R): (obj) => R | undefined;
+    <V, R>(path: Paths, fn: ObjBase<Paths, V, R>, obj): R;
+    <V, R>(path: Paths, fn: ObjBase<Paths, V, R>): (obj) => R;
     (path: Paths): {
-        <R>(fn: (x) => R, obj): R | undefined;
-        <R>(fn: (x) => R): (obj) => R | undefined;
+        <V, R>(fn: ObjBase<Paths, V, R>, obj): R;
+        <V, R>(fn: ObjBase<Paths, V, R>): (obj) => R;
     };
 }
 
@@ -30,4 +30,6 @@ interface PathApply {
  *      pathApply(['a', 'b'], x => 'is ' + x, {a: {b: 2}}); //=> is 2
  *      pathApply(['a', 'b'], x => x > 0, {a: {b: 2}}); //=> true
  */
-export default curryN(3, <R>(paths: Paths = [], fn: (x) => R, obj = {}) => fn(path(paths, obj))) as PathApply;
+export default curryN(3, <R>(paths: Paths = [], fn: ObjBase<Paths, any, any>, obj = {}) =>
+    fn(path(paths, obj), paths, obj)
+) as PathApply;

--- a/src/object/pathSet.ts
+++ b/src/object/pathSet.ts
@@ -1,13 +1,16 @@
 import curryN from '../function/curryN';
 import isObject from '../is/object';
-import { Paths, Prop } from '../typings/types';
+import isNumber from '../is/number';
+import has from './has';
+import assign from '../assign';
+import { Paths, Prop, ReplaceType } from '../typings/types';
 
 interface PathSet {
-    <K extends Prop, V, O>(path: [K], value: V, obj: O): O & Record<K, V>;
-    <K extends Prop, V>(path: [K], value: V): <O>(obj: O) => O & Record<K, V>;
+    <K extends Prop, V, O>(path: [K], value: V, obj: O): ReplaceType<O, K, V>;
+    <K extends Prop, V>(path: [K], value: V): <O>(obj: O) => ReplaceType<O, K, V>;
     <K extends Prop>(path: [K]): {
-        <V, O>(value: V, obj: O): O & Record<K, V>;
-        <V>(value: V): <O>(obj: O) => O & Record<K, V>;
+        <V, O>(value: V, obj: O): ReplaceType<O, K, V>;
+        <V>(value: V): <O>(obj: O) => ReplaceType<O, K, V>;
     };
     <O>(path: Paths, value, obj: O): O;
     (path: Paths, value): <O>(obj: O) => O;
@@ -21,6 +24,9 @@ interface PathSet {
  * Returns the result of "setting" the portion of the given data structure
  * focused by the given paths to the given value.
  *
+ * **Note:** If property in the object is equal to value by reference then function
+ * just returns object without changes
+ *
  * @param {[String]} paths
  * @param {*} value
  * @param {Object} obj
@@ -31,22 +37,28 @@ interface PathSet {
  */
 export default curryN(3, (paths: Paths = [], value, obj = {}) => {
     const n = paths.length - 1;
-    const result = Object.assign({}, obj);
+    const result = assign(obj);
+    const key = paths[n];
     let val = result;
     let v;
 
     for (let i = 0; i < n; i++) {
         v = val[paths[i]];
         if (isObject(v)) {
-            v = Object.assign({}, v);
+            v = assign(v);
         } else {
-            v = {};
+            v = isNumber(paths[i + 1]) ? [] : {};
         }
 
         val[paths[i]] = v;
         val = v;
     }
-    val[paths[n]] = value;
+
+    if (has(key, val) && val[key] === value) {
+        return obj;
+    }
+
+    val[key] = value;
 
     return result;
 }) as PathSet;

--- a/src/object/pathSetBy.ts
+++ b/src/object/pathSetBy.ts
@@ -1,0 +1,66 @@
+import curryN from '../function/curryN';
+import isObject from '../is/object';
+import isNumber from '../is/number';
+import has from './has';
+import assign from '../assign';
+import { ObjBase, Paths, Prop, ReplaceType } from '../typings/types';
+
+interface PathSetBy {
+    <K extends Prop, O extends Record<any, any>, R>(path: [K], fn: ObjBase<K, O[K], R>, obj: O): ReplaceType<O, K, R>;
+    <K extends Prop, V, R>(path: [K], fn: ObjBase<K, V, R>): <O>(obj: O) => ReplaceType<O, K, R>;
+    <K extends Prop>(path: [K]): {
+        <O extends Record<any, any>, R>(fn: ObjBase<K, O[K], R>, obj: O): ReplaceType<O, K, R>;
+        <V, R>(fn: ObjBase<K, V, R>): <O>(obj: O) => ReplaceType<O, K, R>;
+    };
+    <O>(path: Paths, fn: ObjBase<Paths, any, any>, obj: O): O;
+    (path: Paths, fn: ObjBase<Paths, any, any>): <O>(obj: O) => O;
+    (path: Paths): {
+        <O>(fn: ObjBase<Paths, any, any>, obj: O): O;
+        (fn: ObjBase<Paths, any, any>): <O>(obj: O) => O;
+    };
+}
+
+/**
+ * Returns the result of "setting" the portion of the given data structure
+ * focused by the given paths to the result of `fn` call.
+ *
+ * **Note:** If property in the object is equal to value by reference then function
+ * just returns object without changes
+ *
+ * @param {[String]} paths
+ * @param {Function} fn
+ * @param {Object} obj
+ * @return {Object}
+ * @example
+ *
+ *      pathSetBy(['a', 'b'], x => x+1, {a: { b:1 }}) // => { a: { b: 2 } }
+ */
+export default curryN(3, (paths: Paths = [], fn: ObjBase<Paths, any, any>, obj = {}) => {
+    const n = paths.length - 1;
+    const result = assign(obj);
+    const key = paths[n];
+    let val = result;
+    let v;
+
+    for (let i = 0; i < n; i++) {
+        v = val[paths[i]];
+        if (isObject(v)) {
+            v = assign(v);
+        } else {
+            v = isNumber(paths[i + 1]) ? [] : {};
+        }
+
+        val[paths[i]] = v;
+        val = v;
+    }
+
+    const res = fn(val[key], paths, obj);
+
+    if (has(key, val) && val[key] === res) {
+        return obj;
+    }
+
+    val[key] = res;
+
+    return result;
+}) as PathSetBy;

--- a/src/object/propApply.ts
+++ b/src/object/propApply.ts
@@ -1,14 +1,14 @@
 import curryN from '../function/curryN';
 import prop from './prop';
-import { Prop, Func1 } from '../typings/types';
+import { Prop, ObjBase } from '../typings/types';
 
 interface PropApply {
-    <K extends Prop, R, O extends Record<K, any>>(prop: K, fn: (x: O[K]) => R, obj: O): R;
-    <K extends Prop, R>(prop: K, fn: Func1<R>, obj): R;
-    <K extends Prop, R>(prop: K, fn: Func1<R>): (obj) => R;
+    <K extends Prop, R, O extends Record<K, any>>(prop: K, fn: ObjBase<K, O[K], R>, obj: O): R;
+    <K extends Prop, V, R>(prop: K, fn: ObjBase<K, V, R>, obj): R;
+    <K extends Prop, V, R>(prop: K, fn: ObjBase<K, V, R>): (obj) => R;
     <K extends Prop>(prop: K): {
-        <R>(fn: Func1<R>, obj): R;
-        <R>(fn: Func1<R>): (obj) => R;
+        <V, R>(fn: ObjBase<K, V, R>, obj): R;
+        <V, R>(fn: ObjBase<K, V, R>): (obj) => R;
     };
 }
 
@@ -25,4 +25,4 @@ interface PropApply {
  *      propApply('a', x => 'is ' + x, {a: 2}); //=> is 2
  *      propApply('b', x => x > 0, {b: 2}); //=> true
  */
-export default curryN(3, (propName, fn, obj) => fn(prop(propName, obj))) as PropApply;
+export default curryN(3, (propName: Prop, fn, obj) => fn(prop(propName, obj), propName, obj)) as PropApply;

--- a/src/object/propSet.ts
+++ b/src/object/propSet.ts
@@ -1,12 +1,13 @@
 import curryN from '../function/curryN';
-import { Prop } from '../typings/types';
+import { Prop, ReplaceType } from '../typings/types';
+import has from './has';
 
 interface PropSet {
-    <K extends Prop, V, O>(prop: K, val: V, obj: O): O & Record<K, V>;
-    <K extends Prop, V>(prop: K, val: V): <O>(obj: O) => O & Record<K, V>;
+    <K extends Prop, V, O>(prop: K, val: V, obj: O): ReplaceType<O, K, V>;
+    <K extends Prop, V>(prop: K, val: V): <O>(obj: O) => ReplaceType<O, K, V>;
     <K extends Prop>(prop: K): {
-        <V, O>(val: V, obj: O): O & Record<K, V>;
-        <V>(val: V): <O>(obj: O) => O & Record<K, V>;
+        <V, O>(val: V, obj: O): ReplaceType<O, K, V>;
+        <V>(val: V): <O>(obj: O) => ReplaceType<O, K, V>;
     };
 }
 
@@ -15,16 +16,24 @@ interface PropSet {
  * property with the given value. All non-primitive properties are
  * copied by reference.
  *
- * @deprecated use object/propSet instead
+ * **Note:** If property in the object is equal to value by reference then function
+ * just returns object without changes
+ *
  * @param {String} prop The property name to set
  * @param {*} val The new value
  * @param {Object} obj The object to clone
  * @return {Object} A new object equivalent to the original except for the changed property.
  * @example
  *
- *      assoc('c', 3, {a: 1, b: 2}); //=> {a: 1, b: 2, c: 3}
+ *      propSet('c', 3, {a: 1, b: 2}); //=> {a: 1, b: 2, c: 3}
  */
-export default curryN(3, <K extends Prop, V, O>(prop: K, val: V, obj: O = {} as any) => ({
-    ...obj,
-    [prop]: val,
-})) as PropSet;
+export default curryN(3, <K extends Prop>(prop: K, val, obj = {} as any) => {
+    if (has(prop, obj) && obj[prop] === val) {
+        return obj;
+    }
+
+    return {
+        ...obj,
+        [prop]: val,
+    };
+}) as PropSet;

--- a/src/object/propSetBy.ts
+++ b/src/object/propSetBy.ts
@@ -1,0 +1,41 @@
+import curryN from '../function/curryN';
+import { Prop, ReplaceType, ObjBase } from '../typings/types';
+import has from './has';
+import propApply from './propApply';
+
+interface PropSetBy {
+    <K extends Prop, O extends Record<any, any>, R>(prop: K, fn: ObjBase<K, O[K], R>, obj: O): ReplaceType<O, K, R>;
+    <K extends Prop, V, R>(prop: K, fn: ObjBase<K, V, R>): <O>(obj: O) => ReplaceType<O, K, R>;
+    <K extends Prop>(prop: K): {
+        <O extends Record<any, any>, R>(fn: ObjBase<K, O[K], R>, obj: O): ReplaceType<O, K, R>;
+        <V, R>(fn: ObjBase<K, V, R>): <O>(obj: O) => ReplaceType<O, K, R>;
+    };
+}
+
+/**
+ * Makes a shallow clone of an object, setting or overriding the specified
+ * property with the result of `fn` call.
+ *
+ * **Note:** If property in the object is equal to value by reference then function
+ * just returns object without changes
+ *
+ * @param {String} prop The property name to set
+ * @param {Function} fn The function to execute
+ * @param {Object} obj The object to clone
+ * @return {Object} A new object equivalent to the original except for the changed property.
+ * @example
+ *
+ *      propSetBy('a', x => x+1, {a: 1}); //=> {a: 2}
+ */
+export default curryN(3, <K extends Prop>(prop: K, fn: ObjBase<K, any, any>, obj = {} as any) => {
+    const res = propApply(prop, fn, obj);
+
+    if (has(prop, obj) && obj[prop] === res) {
+        return obj;
+    }
+
+    return {
+        ...obj,
+        [prop]: res,
+    };
+}) as PropSetBy;

--- a/src/typings/types.ts
+++ b/src/typings/types.ts
@@ -1,7 +1,7 @@
 export type Ord = number | string | boolean;
 
 export type ArrBase<T, R> = (value: T, index: number, arr: ArrayLike<T>) => R;
-export type ObjBase<K extends Prop, V, R> = (value: V, key: K & string, obj: Record<K, V>) => R;
+export type ObjBase<K extends Prop | Paths, V, R> = (value: V, key: K, obj: Record<K extends Prop ? K : any, V>) => R;
 export type ObjBaseBy<O extends Record<any, any>, R> = (value: O[keyof O], key: keyof O & string, obj: O) => R;
 
 export type CompareFunc<T, R extends Ord> = (a: T, b: T) => R;
@@ -32,6 +32,8 @@ export type Prop = keyof any;
 export type Paths = ReadonlyArray<Prop>;
 
 export type Pattern = RegExp | string;
+
+export type ReplaceType<O, K extends Prop, V> = Pick<O, Exclude<keyof O, K>> & { [p in K]: V };
 
 // @see https://gist.github.com/donnut/fd56232da58d25ceecf1, comment by @albrow
 export interface CurriedTypeGuard2<T1, T2, R extends T2> {


### PR DESCRIPTION
add propSetBy and pathSetBy functions to allow setting values based on the result of function call
add utils/assign to create a shallow copy based on type
propSet, pathSet won't generate new reference when the object itself doesn't change
extend types for propApply, pathApply functions